### PR TITLE
Fixed wb-m1w2

### DIFF
--- a/devices.conf
+++ b/devices.conf
@@ -419,7 +419,7 @@
         },
         "wb-m1w2": {
             "controls": {
-                "^External Sensor": {
+                "^External Sensor \d$": {
                     "type": "temperature"
                 }
             }


### PR DESCRIPTION
Sensor OK property was recognized as temperature sensor due to error in RegEx

Example naming
![CleanShot 2024-01-06 at 14 15 51@2x](https://github.com/4mr/wb-engine/assets/12628139/d502bd30-0c42-466e-b36f-55cc80a6f239)

Here is diff from Autodiscovery
![CleanShot 2024-01-06 at 14 16 17@2x](https://github.com/4mr/wb-engine/assets/12628139/09f4779a-6ca7-456d-9315-78e806134b24)
