### PR TITLE
Add a service to restore device functionality in Home Assistant.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ env:
   MAINTAINER: '4mr https://github.com/4mr/wb-engine'
   DESC: 'WB Engine and HomeAssistant integration'
   DEPENDS: 'wb-mqtt-confed (>= 1.8.1), wb-rules (>= 2.11.4)'
-
 jobs:
   build-linux-packages:
     runs-on: ubuntu-latest
@@ -21,15 +20,42 @@ jobs:
           mkdir -p .debpkg/etc/wb-rules-modules
           mkdir -p .debpkg/usr/bin
           mkdir -p .debpkg/usr/share/wb-mqtt-confed/schemas
+          mkdir -p .debpkg/etc/systemd/system
+          mkdir -p .debpkg/etc/systemd/system/ha-monitor.service.d
 
-          cp devices.conf        .debpkg/etc/wb-rules/wb-engine.devices.conf
-          cp wb-engine-rule.js   .debpkg/etc/wb-rules/wb-engine.js
-          cp wb-engine-module.js .debpkg/etc/wb-rules-modules/wb-engine.js
-          cp wb-engine-helper    .debpkg/usr/bin/wb-engine-helper
-          cp schema.json         .debpkg/usr/share/wb-mqtt-confed/schemas/wb-engine.schema.json
+          cp devices.conf                   .debpkg/etc/wb-rules/wb-engine.devices.conf
+          cp wb-engine-rule.js              .debpkg/etc/wb-rules/wb-engine.js
+          cp wb-engine-module.js            .debpkg/etc/wb-rules-modules/wb-engine.js
+          cp wb-engine-helper               .debpkg/usr/bin/wb-engine-helper
+          cp schema.json                    .debpkg/usr/share/wb-mqtt-confed/schemas/wb-engine.schema.json
+
+          cp ha-monitor                     .debpkg/usr/bin/ha-monitor 
+          chmod +x .debpkg/usr/bin/ha-monitor
+          cp ha-monitor.service             .debpkg/etc/systemd/system/ha-monitor.service
+          cp ha-monitor.service.custom.conf .debpkg/etc/systemd/system/ha-monitor.service.d/custom.conf
 
           mkdir -p .debpkg/DEBIAN
-          echo -e "touch /etc/wb-rules/wb-engine.conf" > .debpkg/DEBIAN/postinst
+
+          echo -e "#!/bin/sh" > .debpkg/DEBIAN/postinst
+          echo -e "touch /etc/wb-rules/wb-engine.conf" >> .debpkg/DEBIAN/postinst
+          SERVICE_NAME=ha-monitor.service
+          echo -e "
+          if command -v systemctl >/dev/null 2>&1; then
+              echo \"Reloading systemd daemon...\"
+              systemctl daemon-reexec || true
+              systemctl daemon-reload || true
+
+              echo \"Enabling $SERVICE_NAME to start on boot...\"
+              systemctl enable \"$SERVICE_NAME\" || true
+
+              echo \"Starting $SERVICE_NAME...\"
+              systemctl start \"$SERVICE_NAME\" || true
+          else
+              echo \"Systemd not found; skipping service setup.\"
+          fi
+
+          exit 0"  >> .debpkg/DEBIAN/postinst
+          
           chmod +x .debpkg/DEBIAN/postinst
       - name: Build armhf
         uses: jiro4989/build-deb-action@v3

--- a/ha-monitor
+++ b/ha-monitor
@@ -6,11 +6,14 @@ import os
 import logging
 import signal
 import traceback
+from time import sleep
+
 import paho.mqtt.client as mqtt
 
 TOPIC_NAME = os.getenv("HA_TOPIC_NAME", "homeassistant/status")
 BROKER_IP = os.getenv("BROKER_IP", "localhost")
 BROKER_PORT = int(os.getenv("BROKER_PORT", "1883"))
+HA_TIMER_AFTER_START_WB_ENGINE = int(os.getenv("HA_TIMER_AFTER_START", "120"))
 
 # setup logging
 logging.basicConfig(
@@ -50,6 +53,8 @@ class SimpleHAStatusMonitor:
             result = client.subscribe(TOPIC_NAME)
             if result[0] == 0:
                 logger.info("Subscribed to %s topic", TOPIC_NAME)
+                sleep(1)
+                self.wb_engine_start()
             else:
                 logger.error("Failed subscribe to %s topic", TOPIC_NAME)
         else:
@@ -117,7 +122,7 @@ class SimpleHAStatusMonitor:
         except Exception as e:
             logger.error("Unexpected error: %s", e)
 
-    def start(self):
+    def start(self, signum=None, frame=None):
         """
         Main function in class
         :return:
@@ -150,4 +155,6 @@ if __name__ == "__main__":
     monitor = SimpleHAStatusMonitor()
     signal.signal(signal.SIGINT, monitor.signal_exit)
     signal.signal(signal.SIGTERM, monitor.signal_exit)
-    monitor.start()
+    signal.signal(signal.SIGALRM, monitor.start)
+    signal.alarm(HA_TIMER_AFTER_START_WB_ENGINE)
+    signal.pause()

--- a/ha-monitor
+++ b/ha-monitor
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import os
+import logging
+import signal
+import traceback
+import paho.mqtt.client as mqtt
+
+TOPIC_NAME = os.getenv("HA_TOPIC_NAME", "homeassistant/status")
+BROKER_IP = os.getenv("BROKER_IP", "localhost")
+BROKER_PORT = int(os.getenv("BROKER_PORT", "1883"))
+
+# setup logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SimpleHAStatusMonitor:
+    """
+    Monitor Home Assistant status via MQTT.
+    """
+
+    def __init__(
+        self,
+        broker=BROKER_IP,
+        port=BROKER_PORT,
+    ):
+        logger.debug("BROKER_IP %s", broker)
+        logger.debug("BROKER_PORT %s", port)
+        self.broker = broker
+        self.port = port
+        self.current_status = None
+        self.previous_status = None
+
+    def on_connect(
+        self,
+        client,
+        userdata,
+        flags,
+        rc,
+    ):
+        if rc == 0:
+            result = client.subscribe(TOPIC_NAME)
+            if result[0] == 0:
+                logger.info("Subscribed to %s topic", TOPIC_NAME)
+            else:
+                logger.error("Failed subscribe to %s topic", TOPIC_NAME)
+        else:
+            logger.error(
+                "Connection error: %s - %s",
+                rc,
+                mqtt.error_string(rc),
+            )
+
+    def on_message(
+        self,
+        client,
+        userdata,
+        msg,
+    ):
+        """
+        Checking status On message in topic
+        :param client:
+        :param userdata:
+        :param msg:
+        :return:
+        """
+        if msg.topic == TOPIC_NAME:
+            new_status = msg.payload.decode().strip().lower()
+            # Save prev status
+            self.previous_status = self.current_status
+            self.current_status = new_status
+            logger.info("Status: %s", new_status)
+            # Check status "online"
+            if (not self.previous_status and self.current_status == "online") or (
+                self.previous_status == "offline" and self.current_status == "online"
+            ):
+                self.wb_engine_start()
+
+    def on_disconnect(self, client, userdata, rc):
+        """
+        Disconnect callback
+        :param client:
+        :param userdata:
+        :param rc:
+        :return:
+        """
+        logger.error("Connection lost")
+
+    def wb_engine_start(self):
+        """
+        Start wb-engine-helper --start
+        :return:
+        """
+        try:
+            logger.info("Try to start wb-engine-helper...")
+            res = subprocess.run(
+                ["wb-engine-helper", "--start"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if res.returncode != 0:
+                logger.error("wb-engine-helper failed with code %s", res.returncode)
+                logger.error("stderr: %s", res.stderr)
+            elif res.stdout.strip():
+                logger.info(res.stdout)
+            else:
+                logger.info("wb-engine-helper started OK")
+        except Exception as e:
+            logger.error("Unexpected error: %s", e)
+
+    def start(self):
+        """
+        Main function in class
+        :return:
+        """
+        client = mqtt.Client()
+        client.on_connect = self.on_connect
+        client.on_message = self.on_message
+        client.on_disconnect = self.on_disconnect
+        try:
+            client.connect(self.broker, self.port, 60)
+            client.reconnect_delay_set(min_delay=1, max_delay=30)
+            client.loop_forever()
+        except Exception as e:
+            logger.error("Error: %s", e)
+            exc_type, exc_val, exc_tb = sys.exc_info()
+            logger.error(traceback.print_exception(exc_type, exc_val, exc_tb))
+
+    def signal_exit(self, signum, frame):
+        """
+        System event listner: SIGTERM, SIGINT
+        :param signum:
+        :param frame:
+        :return:
+        """
+        sys.exit(0)
+
+
+# Starting monitoring
+if __name__ == "__main__":
+    monitor = SimpleHAStatusMonitor()
+    signal.signal(signal.SIGINT, monitor.signal_exit)
+    signal.signal(signal.SIGTERM, monitor.signal_exit)
+    monitor.start()

--- a/ha-monitor.service
+++ b/ha-monitor.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Part of wb-engine for fixing HA after restarting
+After=wb-rules.service
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=2
+RestartPreventExitStatus=2 3 4 5 6
+SuccessExitStatus=7
+ExecStart=/usr/bin/ha-monitor
+
+[Install]
+WantedBy=multi-user.target

--- a/ha-monitor.service.custom.conf
+++ b/ha-monitor.service.custom.conf
@@ -1,0 +1,4 @@
+[Service]
+Environment=HA_TOPIC_NAME=homeassistant/status
+Environment=BROKER_IP=localhost
+Environment=BROKER_PORT=1883


### PR DESCRIPTION
### Исправлена проблема с исчезновением устройств в Home Assistant после перезапуска

Реализован сервис, отслеживающий запуск Home Assistant по MQTT-топику `homeassistant/status`.  
При получении сигнала о старте Home Assistant сервис запускает `wb-engine-helper` с флагом `--start`,  
который публикует необходимые топики устройств. Это обеспечивает их корректное отображение  
в интерфейсе Home Assistant после перезапуска.

В сборку пакета добавлены:
- скрипт запуска,
- конфигурация,
- установка сервиса.

Таким образом, при установке пакета автоматически добавляется `wb-engine`  
и связанный с ним сервис, устраняющий проблему исчезновения устройств в Home Assistant.
